### PR TITLE
Update code.cpp

### DIFF
--- a/code.cpp
+++ b/code.cpp
@@ -22,7 +22,7 @@ unsigned long lastUpdateTime  = 0;
 /*
  * Amount of spark fires in a single interval
  */
-int sparkFireCount            = 0;
+volatile int sparkFireCount            = 0;
 
 /*
  * Rpm value from last update


### PR DESCRIPTION
A variable should be declared volatile whenever its value can be changed by something beyond the control of the code section in which it appears, such as a concurrently executing thread. In the Arduino, the only place that this is likely to occur is in sections of code associated with interrupts, called an interrupt service routine.